### PR TITLE
サイドカーコンテナ（ADOT, CloudWatch Agent）の追加

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -168,6 +168,11 @@ export class CdkStack extends cdk.Stack {
       essential: true,
       environment: {
         CW_CONFIG_CONTENT: JSON.stringify({
+          traces: {
+            traces_collected: {
+              application_signals: {}
+            }
+          },
           logs: {
             metrics_collected: {
               application_signals: {}


### PR DESCRIPTION
## 変更内容
- ECSタスク定義に以下のサイドカーを追加
  - ADOTサイドカーコンテナ（名前: ）
  - CloudWatch Agentサイドカーコンテナ（名前: ）
- タスク実行ロールとタスクロールに必要なIAM権限を追加
  - Application Signals向けのIAMポリシーを追加
  - CloudWatch、X-Ray、Prometheusなどの権限を追加

## 検証ポイント
- コンテナ間通信が正しく設定されているか
- Application Signalsにメトリクスとトレースが送信されるか
- タスクが必要なリソースで起動できるか（メモリ/CPU設定）