### PR TITLE
Jestの設定ファイル構文エラー修正

### DIFF
--- a/cdk/jest.config.js
+++ b/cdk/jest.config.js
@@ -1,17 +1,15 @@
 module.exports = {
-  testEnvironment: 'node',
-  roots: ['<rootDir>/test'],
-  testMatch: ['**/*.test.ts'],
+  testEnvironment: "node",
+  roots: ["<rootDir>/test"],
+  testMatch: ["**/*.test.ts"],
   transform: {
-    '^.+\\.tsx?
-: 'ts-jest'
+    "^.+\.tsx?$": "ts-jest"
   },
-  // JUnit形式のレポート出力を追加（CI用）
   reporters: [
-    'default',
-    ['jest-junit', {
-      outputDirectory: 'test-reports',
-      outputName: 'junit.xml'
+    "default",
+    ["jest-junit", {
+      outputDirectory: "test-reports",
+      outputName: "junit.xml"
     }]
   ]
 };


### PR DESCRIPTION
jest.config.jsファイルの構文エラーを修正しました。\n\n- バックスラッシュと改行の問題を修正\n- スナップショットテストとintegテストが実行できるようになります